### PR TITLE
finish restaurant detail & fix responsive text overflow issue

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,7 +8,7 @@ import RestaurantPage from "components/Restaurant/RestaurantPage";
 import ReviewerPage from "components/Reviewer/ReviewerPage";
 import UserPage from "components/User/UserPage";
 import AnalyticsPage from "components/Analytics/AnalyticsPage";
-import UserDetail from "components/User/UserDetail";
+import RestaurantDetail from "components/Restaurant/RestaurantDetail";
 
 const App = () => {
   return (
@@ -22,7 +22,7 @@ const App = () => {
         <Route path="/reviewer/:reviewerId" element={<ReviewerPage />} />
         <Route path="/user" element={<UserPage />} />
         <Route path="/analytics" element={<AnalyticsPage />} />
-        <Route path="/detail" element={<UserDetail />} />
+        <Route path="/detail" element={<RestaurantDetail />} />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/components/Common/Detail.css
+++ b/client/src/components/Common/Detail.css
@@ -1,0 +1,48 @@
+.det-container {
+  background: #f3f3f3;
+  border: 1px solid #f3f3f3;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  margin-top: -8px;
+  margin-bottom: 20px;
+}
+
+.det-row {
+  margin-left: 10%;
+  min-width: 1000px;
+}
+
+.det-row:hover {
+  cursor: default;
+}
+
+.det-avatar {
+  font-size: 36px !important;
+  background-color: #25c8c1;
+  margin-right: 16px;
+  margin-top: 2px;
+}
+
+.det-name {
+  font-family: "Arvo";
+  font-size: 24px;
+  margin-bottom: 6px;
+  margin-left: 4px;
+}
+
+.det-stats {
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+}
+
+@media only screen and (max-width: 428px) {
+  .det-row {
+    margin-left: 5%;
+    min-width: 350px;
+  }
+
+  .det-name {
+    font-size: 20px;
+  }
+}

--- a/client/src/components/Common/PageDivider.css
+++ b/client/src/components/Common/PageDivider.css
@@ -1,0 +1,29 @@
+.divid-container {
+  border-bottom: 1.5px solid #ebebeb;
+  max-width: 1000px;
+  min-width: 500px;
+  padding-bottom: 16px;
+  margin-left: 10%;
+  margin-bottom: 16px;
+}
+
+.divid-header {
+  font-family: "Arvo";
+  font-weight: 700;
+  font-size: 24px;
+  color: #25c8c1;
+}
+
+.divid-select .ant-select-selection-item {
+  font-weight: 700;
+}
+
+@media only screen and (max-width: 428px) {
+  .divid-text {
+    display: none;
+  }
+
+  .divid-container {
+    margin-left: 5%;
+  }
+}

--- a/client/src/components/Restaurant/RestaurantDetail.css
+++ b/client/src/components/Restaurant/RestaurantDetail.css
@@ -1,0 +1,49 @@
+.restdet-image {
+  width: 225px;
+  height: 225px;
+  margin-right: 40px;
+}
+
+.restdet-details {
+  font-size: 16px;
+}
+
+.restdet-header {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: -8px;
+}
+
+.restdet-icon {
+  width: 26px;
+  height: 26px;
+  margin-left: 250px;
+}
+
+.restdet-score {
+  font-weight: 700;
+  padding-right: 20px;
+  margin-right: 20px;
+  margin-left: 5px;
+}
+
+.restdet-category {
+  font-weight: 700;
+}
+
+.restdet-icon:hover,
+.restdet-address:hover {
+  cursor: pointer;
+}
+
+@media only screen and (max-width: 500px) {
+  .restdet-image {
+    display: none;
+  }
+
+  .restdet-icon {
+    width: 22px;
+    height: 22px;
+    margin-left: 30px;
+  }
+}

--- a/client/src/components/Restaurant/RestaurantDetail.js
+++ b/client/src/components/Restaurant/RestaurantDetail.js
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import { Row, Col, Tooltip, Space, message } from "antd";
+import { StarFilled } from "@ant-design/icons";
+import { splitString, formatRatingScore, formatOpen } from "utils";
+
+const RestaurantDetail = ({
+  restaurantName,
+  reviewCount,
+  address,
+  categories,
+  avgRating,
+  open,
+}) => {
+  // TODO: call hook in useEffect to get saved or not, and populate the saved state.
+  const [restaurantSaved, setRestaurantSaved] = useState(false);
+  const [addressTextCopied, setAddressTextCopied] = useState(false);
+
+  const onBookmarkClick = () => {
+    setRestaurantSaved(!restaurantSaved);
+    // prompt to login (finish localStorage refactor first!)
+    if (restaurantSaved) {
+      // call save restaurants hook
+      message.success("You have successfully unsaved this restaurant.");
+    } else {
+      // call unsave restaurants hook
+      message.success(
+        "You have successfully saved this restaurant to your profile."
+      );
+    }
+  };
+
+  const categoryItems = splitString(categories).map((category) => {
+    return <span key={category}>{category}</span>;
+  });
+
+  return (
+    <div className="det-container">
+      <Row className="det-row" wrap={false}>
+        <Col>
+          <img
+            className="restdet-image"
+            src="/images/restaurant.png"
+            alt="restaurant"
+          />
+        </Col>
+
+        <Col className="restdet-details">
+          <Space direction="vertical" size="middle">
+            <div className="restdet-header">
+              <div className="det-name">{restaurantName}</div>
+              <Tooltip
+                placement="bottom"
+                title={
+                  restaurantSaved ? "Unsave restaurant" : "Save restaurant"
+                }
+              >
+                <img
+                  className="restdet-icon"
+                  src={
+                    restaurantSaved
+                      ? "/icons/bookmark-fill.svg"
+                      : "/icons/bookmark.svg"
+                  }
+                  alt="bookmark"
+                  onClick={onBookmarkClick}
+                />
+              </Tooltip>
+            </div>
+
+            <div className="det-stats">
+              <StarFilled style={{ color: "#FF643D", fontSize: "26px" }} />
+              <div className="restdet-score">
+                {formatRatingScore(avgRating)}
+              </div>
+              <div>
+                {reviewCount} {reviewCount === 1 ? "Review" : "Reviews"}
+              </div>
+            </div>
+
+            <div className="restdet-category">
+              <Space direction="horizontal" size="middle">
+                {categoryItems}
+              </Space>
+            </div>
+
+            <Tooltip
+              placement="bottom"
+              title={
+                addressTextCopied ? "Text copied!" : "Copy text to clipboard"
+              }
+            >
+              <div
+                className="restdet-address"
+                onClick={() => {
+                  setAddressTextCopied(true);
+                  navigator.clipboard.writeText(address);
+                }}
+              >
+                {address}
+              </div>
+            </Tooltip>
+
+            <div className={open === "Y" ? "restitem-open" : "restitem-closed"}>
+              {formatOpen(open)}
+            </div>
+          </Space>
+        </Col>
+      </Row>
+    </div>
+  );
+};
+
+export default RestaurantDetail;

--- a/client/src/components/Restaurant/RestaurantPage.js
+++ b/client/src/components/Restaurant/RestaurantPage.js
@@ -2,10 +2,11 @@ import React, { useState } from "react";
 import { Layout, Affix, List } from "antd";
 import AppHeader from "components/Header/AppHeader";
 import AppFooter from "components/Footer/AppFooter";
+import RestaurantDetail from "./RestaurantDetail";
 import ReviewPageDivider from "./ReviewPageDivider";
 import RestaurantReviewItem from "./RestaurantReviewItem";
 import EmptyItem from "components/Common/EmptyItem";
-import { reviewListData } from "constants/mock";
+import { restaurantItemData, reviewListData } from "constants/mock";
 
 const { Content, Footer } = Layout;
 
@@ -31,6 +32,8 @@ const RestaurantPage = () => {
       </Affix>
 
       <Content>
+        <RestaurantDetail {...restaurantItemData} />
+
         <ReviewPageDivider
           searchParams={searchParams}
           setSearchParams={setSearchParams}

--- a/client/src/components/Restaurant/RestaurantReviewItem.css
+++ b/client/src/components/Restaurant/RestaurantReviewItem.css
@@ -24,6 +24,7 @@
 .restrevitem-name-container {
   display: flex;
   align-items: center;
+  min-width: 500px;
 }
 
 .restrevitem-name {

--- a/client/src/components/Restaurant/RestaurantReviewItem.js
+++ b/client/src/components/Restaurant/RestaurantReviewItem.js
@@ -25,7 +25,7 @@ const RestaurantReviewItem = (props) => {
 
   return (
     <div className="restrevitem-container">
-      <Row>
+      <Row wrap={false}>
         <Col>
           <Tooltip placement="bottom" title="Reviewer Profile">
             <Avatar

--- a/client/src/components/Restaurant/ReviewPageDivider.css
+++ b/client/src/components/Restaurant/ReviewPageDivider.css
@@ -1,23 +1,3 @@
-.divid-container {
-  border-bottom: 1.5px solid #ebebeb;
-  max-width: 1000px;
-  min-width: 500px;
-  padding-bottom: 16px;
-  margin-left: 10%;
-  margin-bottom: 16px;
-}
-
-.divid-header {
-  font-family: "Arvo";
-  font-weight: 700;
-  font-size: 24px;
-  color: #25c8c1;
-}
-
-.divid-select .ant-select-selection-item {
-  font-weight: 700;
-}
-
 .revdivid-filter,
 .revdivid-sort {
   display: flex;
@@ -34,14 +14,6 @@
 }
 
 @media only screen and (max-width: 428px) {
-  .divid-container {
-    margin-left: 5%;
-  }
-
-  .divid-text {
-    display: none;
-  }
-
   .revdivid-filter {
     margin-left: 35px;
   }

--- a/client/src/components/RestaurantList/RestaurantItem.css
+++ b/client/src/components/RestaurantList/RestaurantItem.css
@@ -76,8 +76,8 @@
 
 @media only screen and (max-width: 375px) {
   .restitem-image {
-    height: 65px;
-    width: 65px;
+    height: 80px;
+    width: 80px;
     margin-right: -20px;
   }
 }

--- a/client/src/components/RestaurantList/RestaurantListPage.css
+++ b/client/src/components/RestaurantList/RestaurantListPage.css
@@ -38,7 +38,17 @@
 }
 
 @media only screen and (max-width: 428px) {
+  .restlist-items {
+    min-width: 300px;
+  }
+
   .restlist-item {
     margin-left: 2%;
+  }
+}
+
+@media only screen and (max-width: 375px) {
+  .restlist-items {
+    min-width: 200px;
   }
 }

--- a/client/src/components/Reviewer/ReviewItem.css
+++ b/client/src/components/Reviewer/ReviewItem.css
@@ -42,3 +42,15 @@
     font-size: 16px;
   }
 }
+
+@media only screen and (max-width: 428px) {
+  .revitem-container {
+    min-width: 300px;
+  }
+}
+
+@media only screen and (max-width: 375px) {
+  .revitem-container {
+    min-width: 200px;
+  }
+}

--- a/client/src/components/Reviewer/ReviewItem.js
+++ b/client/src/components/Reviewer/ReviewItem.js
@@ -15,12 +15,12 @@ const ReviewItem = ({
 }) => {
   const navigate = useNavigate();
 
-  const restaurantName = "Black Chile Mexican Grill";
+  const restaurantName = "Fry's Food & Drug Stores & Fry's Marketplace";
   const restaurantId = "_-9pMxBWtG_x8l4rHWBasg";
 
   return (
     <div className="revitem-container">
-      <Row>
+      <Row wrap={false}>
         <Col>
           <Tooltip placement="bottom" title="View Restaurant">
             <img

--- a/client/src/components/Reviewer/ReviewRate.css
+++ b/client/src/components/Reviewer/ReviewRate.css
@@ -1,6 +1,7 @@
 .rev-rate-container {
   display: flex;
   align-items: center;
+  min-width: 500px;
 }
 
 .rev-date {

--- a/client/src/components/Reviewer/ReviewVote.css
+++ b/client/src/components/Reviewer/ReviewVote.css
@@ -3,6 +3,7 @@
   color: #606060;
   display: flex;
   align-items: center;
+  min-width: 500px;
 }
 
 .rev-vote {

--- a/client/src/components/Reviewer/ReviewerDetail.css
+++ b/client/src/components/Reviewer/ReviewerDetail.css
@@ -1,54 +1,11 @@
-.det-container {
-  background: #f3f3f3;
-  border: 1px solid #f3f3f3;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  margin-top: -8px;
-  margin-bottom: 20px;
-}
-
-.det-container .rev-vote-container {
-  font-size: 16px;
-}
-
-.det-row {
-  margin-left: 10%;
-  min-width: 550px;
-}
-
-.det-row:hover {
-  cursor: default;
-}
-
-.det-avatar {
-  font-size: 36px !important;
-  background-color: #25c8c1;
-  margin-right: 16px;
-  margin-top: 2px;
-}
-
-.det-name {
-  font-family: "Arvo";
-  font-size: 24px;
-  margin-bottom: 6px;
-  margin-left: 4px;
-}
-
-.det-stats {
-  display: flex;
-  align-items: center;
-}
-
 .reviewerdet-score {
   font-weight: 700;
-  font-size: 16px;
   color: #000000;
   margin-right: 20px;
   margin-left: 5px;
 }
 
 .reviewerdet-count {
-  font-size: 16px;
   margin-right: 20px;
 }
 
@@ -68,9 +25,5 @@
 @media only screen and (max-width: 428px) {
   .reviewerdet-vote-container {
     display: none;
-  }
-
-  .det-row {
-    margin-left: 5%;
   }
 }

--- a/client/src/components/Reviewer/ReviewerDetail.js
+++ b/client/src/components/Reviewer/ReviewerDetail.js
@@ -2,12 +2,15 @@ import React from "react";
 import { Row, Col, Avatar } from "antd";
 import { StarFilled } from "@ant-design/icons";
 import { getInitial } from "utils";
-import { reviewerItemData } from "constants/mock";
 
-const ReviewerDetail = (props) => {
-  const { name, avgRating, funnyCount, usefulCount, coolCount, reviewCount } =
-    reviewerItemData;
-
+const ReviewerDetail = ({
+  name,
+  avgRating,
+  funnyCount,
+  usefulCount,
+  coolCount,
+  reviewCount,
+}) => {
   return (
     <div className="det-container">
       <Row className="det-row">

--- a/client/src/components/Reviewer/ReviewerPage.js
+++ b/client/src/components/Reviewer/ReviewerPage.js
@@ -32,7 +32,7 @@ const ReviewerPage = () => {
       </Affix>
 
       <Content>
-        <ReviewerDetail reviewer={reviewerItemData} />
+        <ReviewerDetail {...reviewerItemData} />
 
         <ReviewPageDivider
           searchParams={searchParams}

--- a/client/src/components/User/UserDetail.css
+++ b/client/src/components/User/UserDetail.css
@@ -6,7 +6,6 @@
 }
 
 .userdet-text {
-  font-size: 16px;
   display: flex;
 }
 

--- a/client/src/constants/mock.js
+++ b/client/src/constants/mock.js
@@ -1,8 +1,8 @@
 export const restaurantItemData = {
   restaurantId: "_-9pMxBWtG_x8l4rHWBasg",
-  restaurantName: "Black Chile Mexican Grill",
+  restaurantName: "Fry's Food & Drug Stores & Fry's Marketplace",
   reviewCount: 98,
-  address: "2502 E Camelback Rd Phoenix, AZ 85016",
+  address: "2502 E Camelback Rd Phoenix, AZ 85016 zsdfghdsadfghfdszAdfghjgfdszdfghjkgfdsfghjk",
   categories: "Mexican, Restaurants",
   avgRating: 3,
   open: "Y",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -15,6 +15,7 @@
 @import "components/Restaurant/RestaurantPage.css";
 @import "components/Restaurant/RestaurantReviewItem.css";
 @import "components/Restaurant/ReviewPageDivider.css";
+@import "components/Restaurant/RestaurantDetail.css";
 @import "components/RestaurantList/RestaurantCard.css";
 @import "components/RestaurantList/RestaurantItem.css";
 @import "components/RestaurantList/RestaurantListPage.css";
@@ -27,6 +28,8 @@
 @import "components/User/UserDetail.css";
 @import "components/User/SavedPageDivider.css";
 @import "components/Common/EmptyItem.css";
+@import "components/Common/Detail.css";
+@import "components/Common/PageDivider.css";
 /* Global */
 .ant-form-item-label label,
 #basic_username,


### PR DESCRIPTION
For a row with image on the left hand side and text container on the right hand side,

We want the overflowed text to wrap to the next line;

We don't want the whole text container to wrap to the next row below the image;

For RestaurantDetail particularly, we want the bookmark icon to be always visible so that users can use this feature on phone.

Workaround:
1. Set `wrap=false` to AntD Row;
2. Adjust `min-width` property of div containers for different breakpoint widths